### PR TITLE
comment out invalid field goals from load_sample_data script

### DIFF
--- a/core/management/commands/load_sample_data.py
+++ b/core/management/commands/load_sample_data.py
@@ -165,11 +165,12 @@ class Command(BaseCommand):
                 'start_date': date.today(),
                 'end_date': date.today() + timedelta(days=180),
                 'is_open_for_collaboration': True,
-                'goals': [
-                    'Plant 500 trees in school grounds',
-                    'Engage 200+ students in environmental activities',
-                    'Reduce school waste by 30%'
-                ],
+                # goals is not in the schema?
+                # 'goals': [
+                #     'Plant 500 trees in school grounds',
+                #     'Engage 200+ students in environmental activities',
+                #     'Reduce school waste by 30%'
+                # ],
                 'offer_rewards': True,
                 'recognition_type': 'Certificate of Environmental Excellence',
                 'award_criteria': 'Active participation in all project phases',


### PR DESCRIPTION
while trying to run the backend locally(in the github codespace for my case), the command
```
python manage.py load_sample_data
```
returned an error regarding the failure of Project creation because of the invalid field 'goals'.
i simply just commented out the part causing the problem so that i could proceed with my task